### PR TITLE
Clean up the data format.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1770,7 +1770,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1788,11 +1789,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1805,15 +1808,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1916,7 +1922,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1926,6 +1933,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1938,17 +1946,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1965,6 +1976,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2037,7 +2049,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2047,6 +2060,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2122,7 +2136,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2152,6 +2167,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2169,6 +2185,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2207,11 +2224,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/public/_helpers.html
+++ b/public/_helpers.html
@@ -88,13 +88,20 @@
   htc_vive: htc_vive,
   "oculus_rift": {
     "name": "Oculus Rift",
-    "about": "/oculus_rift"
+    "about": "/oculus_rift",
+    "platforms": [
+      "windows"
+    ]
   },
   samsung_gear_vr: samsung_gear_vr,
   google_daydream: google_daydream,
   "google_cardboard": {
     "name": "Google Cardboard",
-    "about": "/google_cardboard"
+    "about": "/google_cardboard",
+    "platforms": [
+      "android",
+      "ios"
+    ]
   },
   windows_mixed_reality: windows_mixed_reality
 } %}
@@ -207,12 +214,14 @@
       {% set supported_headsets = [] %}
       {% set supported_platforms = [] %}
       {% for os, os_headsets in browser.platforms %}
-        {% for headset, _ in headsets %}
-          {% if os not in supported_platforms %}
-            {% set supported_platforms = supported_platforms.concat([os]) %}
-          {% endif %}
-          {% if headset not in supported_headsets %}
-            {% set supported_headsets = supported_headsets.concat([headset]) %}
+        {% for headset, headset_data in headsets %}
+          {% if os in headset_data.platforms %}
+            {% if os not in supported_platforms %}
+              {% set supported_platforms = supported_platforms.concat([os]) %}
+            {% endif %}
+            {% if headset not in supported_headsets %}
+              {% set supported_headsets = supported_headsets.concat([headset]) %}
+            {% endif %}
           {% endif %}
         {% endfor %}
       {% endfor %}

--- a/public/_helpers.html
+++ b/public/_helpers.html
@@ -143,18 +143,13 @@
 } %}
 
 {% macro browser_platform_support (browser, headset, os) %}
-  {% set support = browser.platforms[headset][os] %}
-  {% if support === 'supported' %}
+  {% if os in browser.platforms and headset in browser.platforms[os] %}
     {% set classes = 'no-underline supported' %}
     {% set title = 'Supported' %}
     {% set text = '✅ <strong>Supported</strong>'|safe %}
-  {% elif support === 'headset_unsupported' %}
-    {% set classes = 'no-underline unsupported headset-unsupported' %}
-    {% set title = 'Unsupported OS by headset maker' %}
-    {% set text = '❌' %}
-  {% elif support === 'browser_unsupported' %}
-    {% set classes = 'no-underline unsupported browser-unsupported' %}
-    {% set title = 'Unsupported browser support' %}
+  {% else %}
+    {% set classes = 'no-underline unsupported' %}
+    {% set title = 'Unsupported' %}
     {% set text = '❌' %}
   {% endif %}
   {% if title %}
@@ -211,15 +206,13 @@
 
       {% set supported_headsets = [] %}
       {% set supported_platforms = [] %}
-      {% for headset, operating_systems in browser.platforms %}
-        {% for os, support_status in operating_systems %}
-          {% if support_status == 'supported' %}
-            {% if os not in supported_platforms %}
-              {% set supported_platforms = supported_platforms.concat([os]) %}
-            {% endif %}
-            {% if headset not in supported_headsets %}
-              {% set supported_headsets = supported_headsets.concat([headset]) %}
-            {% endif %}
+      {% for os, os_headsets in browser.platforms %}
+        {% for headset, _ in headsets %}
+          {% if os not in supported_platforms %}
+            {% set supported_platforms = supported_platforms.concat([os]) %}
+          {% endif %}
+          {% if headset not in supported_headsets %}
+            {% set supported_headsets = supported_headsets.concat([headset]) %}
           {% endif %}
         {% endfor %}
       {% endfor %}
@@ -228,62 +221,20 @@
         <thead>
           <tr>
             <th></th>
-            <th data-platform="windows"><a class="no-underline" href="/windows"><span class="hidden-text">Windows</span></a></th>
-            <th data-platform="mac"><a class="no-underline" href="/mac"><span class="hidden-text">Mac</span></a></th>
-            <th data-platform="linux"><a class="no-underline" href="/linux"><span class="hidden-text">Linux</span></a></th>
-            <th data-platform="android"><a class="no-underline" href="/android"><span class="hidden-text">Android</span></a></th>
-            <th data-platform="ios"><a class="no-underline" href="/ios"><span class="hidden-text">iOS</span></a></th>
+            {% for platform in supported_platforms %}
+              <th data-platform="{{ platform }}"><a class="no-underline" href="/{{ platform }}"><span class="hidden-text">{{ platforms[platform] }}</span></a></th>
+            {% endfor %}
           </tr>
         </thead>
         <tbody>
-          <tr data-headset="htc_vive">
-            <th><a class="no-underline" href="{{ headsets.htc_vive.about }}"><span class="hidden-text">{{ headsets.htc_vive.name }}</span></a></th>
-            <td data-platform="windows">{{ browser_platform_support(browser, 'htc_vive', 'windows') }}</td>
-            <td data-platform="mac">{{ browser_platform_support(browser, 'htc_vive', 'mac') }}</td>
-            <td data-platform="linux">{{ browser_platform_support(browser, 'htc_vive', 'linux') }}</td>
-            <td data-platform="android">{{ browser_platform_support(browser, 'htc_vive', 'android') }}</td>
-            <td data-platform="ios">{{ browser_platform_support(browser, 'htc_vive', 'ios') }}</td>
-          </tr>
-          <tr data-headset="oculus_rift">
-            <th><a class="no-underline" href="{{ headsets.oculus_rift.about }}"><span class="hidden-text">{{ headsets.oculus_rift.name }}</span></a></th>
-            <td data-platform="windows">{{ browser_platform_support(browser, 'oculus_rift', 'windows') }}</td>
-            <td data-platform="mac">{{ browser_platform_support(browser, 'oculus_rift', 'mac') }}</td>
-            <td data-platform="linux">{{ browser_platform_support(browser, 'oculus_rift', 'linux') }}</td>
-            <td data-platform="android">{{ browser_platform_support(browser, 'oculus_rift', 'android') }}</td>
-            <td data-platform="ios">{{ browser_platform_support(browser, 'oculus_rift', 'ios') }}</td>
-          </tr>
-          <tr data-headset="samsung_gear_vr">
-            <th><a class="no-underline" href="{{ headsets.samsung_gear_vr.about }}"><span class="hidden-text">{{ headsets.samsung_gear_vr.name }}</span></a></th>
-            <td data-platform="windows">{{ browser_platform_support(browser, 'samsung_gear_vr', 'windows') }}</td>
-            <td data-platform="mac">{{ browser_platform_support(browser, 'samsung_gear_vr', 'mac') }}</td>
-            <td data-platform="linux">{{ browser_platform_support(browser, 'samsung_gear_vr', 'linux') }}</td>
-            <td data-platform="android">{{ browser_platform_support(browser, 'samsung_gear_vr', 'android') }}</td>
-            <td data-platform="ios">{{ browser_platform_support(browser, 'samsung_gear_vr', 'ios') }}</td>
-          </tr>
-          <tr data-headset="google_daydream">
-            <th><a class="no-underline" href="{{ headsets.google_daydream.about }}"><span class="hidden-text">{{ headsets.google_daydream.name }}</span></a></th>
-            <td data-platform="windows">{{ browser_platform_support(browser, 'google_daydream', 'windows') }}</td>
-            <td data-platform="mac">{{ browser_platform_support(browser, 'google_daydream', 'mac') }}</td>
-            <td data-platform="linux">{{ browser_platform_support(browser, 'google_daydream', 'linux') }}</td>
-            <td data-platform="android">{{ browser_platform_support(browser, 'google_daydream', 'android') }}</td>
-            <td data-platform="ios">{{ browser_platform_support(browser, 'google_daydream', 'ios') }}</td>
-          </tr>
-          <tr data-headset="google_cardboard">
-            <th><a class="no-underline" href="{{ headsets.google_cardboard.about }}"><span class="hidden-text">{{ headsets.google_cardboard.name }}</span></a></th>
-            <td data-platform="windows">{{ browser_platform_support(browser, 'google_cardboard', 'windows') }}</td>
-            <td data-platform="mac">{{ browser_platform_support(browser, 'google_cardboard', 'mac') }}</td>
-            <td data-platform="linux">{{ browser_platform_support(browser, 'google_cardboard', 'linux') }}</td>
-            <td data-platform="android">{{ browser_platform_support(browser, 'google_cardboard', 'android') }}</td>
-            <td data-platform="ios">{{ browser_platform_support(browser, 'google_cardboard', 'ios') }}</td>
-          </tr>
-          <tr data-headset="windows_mixed_reality">
-            <th><a class="no-underline" href="{{ headsets.windows_mixed_reality.about }}"><span class="hidden-text">{{ headsets.windows_mixed_reality.name }} headsets</span></a></th>
-            <td data-platform="windows">{{ browser_platform_support(browser, 'windows_mixed_reality', 'windows') }}</td>
-            <td data-platform="mac">{{ browser_platform_support(browser, 'windows_mixed_reality', 'mac') }}</td>
-            <td data-platform="linux">{{ browser_platform_support(browser, 'windows_mixed_reality', 'linux') }}</td>
-            <td data-platform="android">{{ browser_platform_support(browser, 'windows_mixed_reality', 'android') }}</td>
-            <td data-platform="ios">{{ browser_platform_support(browser, 'windows_mixed_reality', 'ios') }}</td>
-          </tr>
+          {% for headset in supported_headsets %}
+            <tr data-headset="{{ headset }}">
+              <th><a class="no-underline" href="{{ headsets[headset].about }}"><span class="hidden-text">{{ headsets[headset].name }}</span></a></th>
+              {% for platform in supported_platforms %}
+                <td data-platform="{{ platform }}">{{ browser_platform_support(browser, headset, platform) }}</th>
+              {% endfor %}
+            </tr>
+          {% endfor %}
         </tbody>
       </table>
     </div>

--- a/public/_helpers.html
+++ b/public/_helpers.html
@@ -154,9 +154,13 @@
     {% set classes = 'no-underline supported' %}
     {% set title = 'Supported' %}
     {% set text = '✅ <strong>Supported</strong>'|safe %}
+  {% elif os not in headsets[headset].platforms %}
+    {% set classes = 'no-underline unsupported headset-unsupported' %}
+    {% set title = 'Unsupported OS by headset maker' %}
+    {% set text = '<i>N/A</i>'|safe %}
   {% else %}
-    {% set classes = 'no-underline unsupported' %}
-    {% set title = 'Unsupported' %}
+    {% set classes = 'no-underline unsupported browser-unsupported' %}
+    {% set title = 'Unsupported browser support' %}
     {% set text = '❌' %}
   {% endif %}
   {% if title %}

--- a/public/_layout_headset.html
+++ b/public/_layout_headset.html
@@ -69,9 +69,9 @@
             <h2><a href="#browsers">{{ demos_heading or demos_title or 'Supported browsers' }}</a></h2>
             {% block browsers %}
               {% set browsers_list = [] %}
-              {% for os, browsers in headset.platforms %}
-                {% for browser in browsers %}
-                  {% if browser not in browsers_list %}
+              {% for browser, browser_data in browsers %}
+                {% for os, browser_headsets in browser_data.platforms %}
+                  {% if headset.slug in browser_headsets and browser not in browsers_list %}
                     {% set browsers_list = (browsers_list.push(browser), browsers_list) %}
                   {% endif %}
                 {% endfor %}

--- a/public/chrome.json
+++ b/public/chrome.json
@@ -43,48 +43,11 @@
   "alternateName": "Chrome WebVR",
   "audio": "",
   "platforms": {
-    "htc_vive": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "oculus_rift": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "samsung_gear_vr": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "google_daydream": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "supported",
-      "ios": "headset_unsupported"
-    },
-    "google_cardboard": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "supported",
-      "ios": "browser_unsupported"
-    },
-    "windows_mixed_reality": {
-      "windows": "browser_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    }
+    "windows": [],
+    "mac": [],
+    "linux": [],
+    "android": ["google_cardboard", "google_daydream"],
+    "ios": []
   },
   "reports": [
   ],

--- a/public/chrome_for_android.json
+++ b/public/chrome_for_android.json
@@ -97,48 +97,10 @@
     }
   },
   "platforms": {
-    "htc_vive": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "browser_unsupported"
-    },
-    "oculus_rift": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "browser_unsupported"
-    },
-    "samsung_gear_vr": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "google_daydream": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "supported",
-      "ios": "browser_unsupported"
-    },
-    "google_cardboard": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "supported",
-      "ios": "browser_unsupported"
-    },
-    "windows_mixed_reality": {
-      "windows": "browser_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    }
+    "android": [
+      "google_daydream",
+      "google_cardboard"
+    ]
   },
   "notifications": [
     {

--- a/public/chromium.json
+++ b/public/chromium.json
@@ -70,48 +70,17 @@
   "alternateName": "Chromium WebVR",
   "audio": "",
   "platforms": {
-    "htc_vive": {
-      "windows": "supported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "oculus_rift": {
-      "windows": "supported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "samsung_gear_vr": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "google_daydream": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "supported",
-      "ios": "headset_unsupported"
-    },
-    "google_cardboard": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "supported",
-      "ios": "browser_unsupported"
-    },
-    "windows_mixed_reality": {
-      "windows": "browser_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    }
+    "windows": [
+      "htc_vive",
+      "oculus_rift"
+    ],
+    "mac": [],
+    "linux": [],
+    "android": [
+      "google_daydream",
+      "google_cardboard"
+    ],
+    "ios": []
   },
   "reports": [
     {

--- a/public/firefox.json
+++ b/public/firefox.json
@@ -88,48 +88,18 @@
     }
   },
   "platforms": {
-    "htc_vive": {
-      "windows": "supported",
-      "mac": "supported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "oculus_rift": {
-      "windows": "supported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "samsung_gear_vr": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "google_daydream": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "google_cardboard": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "browser_unsupported"
-    },
-    "windows_mixed_reality": {
-      "windows": "browser_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    }
+    "windows": [
+      "htc_vive",
+      "oculus_rift"
+    ],
+    "mac": [
+      "htc_vive"
+    ],
+    "linux": [
+    ],
+    "android": [
+    ],
+    "ios": []
   },
   "links": [
     {

--- a/public/google_daydream.json
+++ b/public/google_daydream.json
@@ -64,50 +64,9 @@
   "device": "",
   "alternateName": "Chromium WebVR",
   "audio": "",
-  "platforms": {
-    "htc_vive": {
-      "windows": "supported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "oculus_rift": {
-      "windows": "supported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "samsung_gear_vr": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "google_daydream": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "supported",
-      "ios": "headset_unsupported"
-    },
-    "google_cardboard": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "supported",
-      "ios": "browser_unsupported"
-    },
-    "windows_mixed_reality": {
-      "windows": "browser_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    }
-  },
+  "platforms": [
+    "android"
+  ],
   "reports": [
     {
       "type": "bug",

--- a/public/htc_vive.json
+++ b/public/htc_vive.json
@@ -63,18 +63,10 @@
   "softwareAddOn": "",
   "device": "",
   "audio": "",
-  "platforms": {
-    "windows": [
-      "firefox",
-      "chromium"
-    ],
-    "mac": [
-      "firefox"
-    ],
-    "linux": [],
-    "android": [],
-    "ios": []
-  },
+  "platforms": [
+    "windows",
+    "mac"
+  ],
   "reports": [
     {
       "type": "bug",

--- a/public/index.html
+++ b/public/index.html
@@ -49,13 +49,9 @@
         <section id="browsers" class="section browsers" data-section="browsers">
           <h1><a href="#browsers">WebVR Browsers</a></h1>
           <ul data-section="browsers" class="matrix grid-flex-container">
-            {{ browser_item('firefox') }}
-            {{ browser_item('microsoft_edge') }}
-            {{ browser_item('chrome_for_android') }}
-            {{ browser_item('chromium') }}
-            {{ browser_item('samsung_internet') }}
-            {{ browser_item('oculus_browser') }}
-            {{ browser_item('servo') }}
+              {% for _, browser in browsers %}
+                {{ browser_item(browser.slug) }}
+              {% endfor %}
           </ul>
         </section>
       </div>

--- a/public/media/css/main.css
+++ b/public/media/css/main.css
@@ -1023,24 +1023,6 @@ html[data-layout] [data-section="demos"] ul.matrix {
   display: table-cell;
 }
 
-[itemprop="browser"] [data-platform="linux"],
-[itemprop="browser"][data-slug="firefox"] tr[data-headset="samsung_gear_vr"],
-[itemprop="browser"][data-slug="firefox"] tr[data-headset="google_daydream"],
-[itemprop="browser"][data-slug="firefox"] tr[data-headset="google_cardboard"],
-[itemprop="browser"][data-slug="chromium"] tr[data-headset="samsung_gear_vr"],
-[itemprop="browser"][data-app-type="MobileApplication"] tr[data-headset="htc_vive"],
-[itemprop="browser"][data-app-type="MobileApplication"] tr[data-headset="oculus_rift"],
-[itemprop="browser"][data-app-type="MobileApplication"] tr[data-headset="windows_mixed_reality"],
-[itemprop="browser"][data-app-type="MobileApplication"] [data-platform="windows"],
-[itemprop="browser"][data-app-type="MobileApplication"] [data-platform="mac"],
-[itemprop="browser"][data-app-type="MobileApplication"] [data-platform="linux"],
-[itemprop="browser"][data-slug="microsoft_edge"] tr[data-headset="samsung_gear_vr"],
-[itemprop="browser"][data-slug="microsoft_edge"] tr[data-headset="google_daydream"],
-[itemprop="browser"][data-slug="microsoft_edge"] tr[data-headset="google_cardboard"],
-[itemprop="browser"][data-slug="microsoft_edge"] [data-platform]:not([data-platform="windows"]) {
-  display: none;
-}
-
 .table-support .unsupported {
   cursor: not-allowed;
 }

--- a/public/microsoft_edge.json
+++ b/public/microsoft_edge.json
@@ -37,48 +37,9 @@
     "description": "Mixed-reality smart-glasses"
   },
   "platforms": {
-    "htc_vive": {
-      "windows": "browser_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "oculus_rift": {
-      "windows": "browser_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "samsung_gear_vr": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "google_daydream": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "google_cardboard": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "browser_unsupported"
-    },
-    "windows_mixed_reality": {
-      "windows": "supported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    }
+    "windows": [
+      "windows_mixed_reality"
+    ]
   },
   "notifications": [
     {

--- a/public/oculus_browser.json
+++ b/public/oculus_browser.json
@@ -50,47 +50,8 @@
   },
   "fileSize": "87.74 MB",
   "platforms": {
-    "htc_vive": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "browser_unsupported"
-    },
-    "oculus_rift": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "browser_unsupported"
-    },
-    "samsung_gear_vr": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "supported",
-      "ios": "headset_unsupported"
-    },
-    "google_daydream": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "browser_unsupported"
-    },
-    "google_cardboard": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "browser_unsupported"
-    },
-    "windows_mixed_reality": {
-      "windows": "browser_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    }
+    "android": [
+      "samsung_gear_vr"
+    ]
   }
 }

--- a/public/samsung_gear_vr.json
+++ b/public/samsung_gear_vr.json
@@ -71,16 +71,9 @@
   "softwareAddOn": "",
   "device": "",
   "audio": "",
-  "platforms": {
-    "windows": [],
-    "mac": [],
-    "linux": [],
-    "android": [
-      "oculus_browser",
-      "samsung_internet"
-    ],
-    "ios": []
-  },
+  "platforms": [
+    "android"
+  ],
   "reports": [
   ],
   "notifications": [

--- a/public/samsung_internet.json
+++ b/public/samsung_internet.json
@@ -27,47 +27,9 @@
   },
   "fileSize": "",
   "platforms": {
-    "htc_vive": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "browser_unsupported"
-    },
-    "oculus_rift": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "browser_unsupported"
-    },
-    "samsung_gear_vr": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "supported",
-      "ios": "headset_unsupported"
-    },
-    "google_daydream": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "browser_unsupported"
-    },
-    "google_cardboard": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "supported",
-      "ios": "browser_unsupported"
-    },
-    "windows_mixed_reality": {
-      "windows": "browser_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    }
+    "android": [
+      "samsung_gear_vr",
+      "google_cardboard"
+    ]
   }
 }

--- a/public/servo.json
+++ b/public/servo.json
@@ -66,47 +66,15 @@
     }
   },
   "platforms": {
-    "htc_vive": {
-      "windows": "supported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "oculus_rift": {
-      "windows": "browser_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "samsung_gear_vr": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "supported",
-      "ios": "headset_unsupported"
-    },
-    "google_daydream": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "supported",
-      "ios": "headset_unsupported"
-    },
-    "google_cardboard": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "browser_unsupported"
-    },
-    "windows_mixed_reality": {
-      "windows": "browser_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    }
+    "windows": [
+      "htc_vive"
+    ],
+    "mac": [],
+    "linux": [],
+    "android": [
+      "samsung_gear_vr",
+      "google_daydream"
+    ],
+    "ios": []
   }
 }

--- a/public/windows_mixed_reality.json
+++ b/public/windows_mixed_reality.json
@@ -52,48 +52,7 @@
   "device": "",
   "alternateName": "Chromium WebVR",
   "audio": "",
-  "platforms": {
-    "htc_vive": {
-      "windows": "supported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "oculus_rift": {
-      "windows": "supported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "samsung_gear_vr": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "browser_unsupported",
-      "ios": "headset_unsupported"
-    },
-    "google_daydream": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "supported",
-      "ios": "headset_unsupported"
-    },
-    "google_cardboard": {
-      "windows": "headset_unsupported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "supported",
-      "ios": "browser_unsupported"
-    },
-    "windows_mixed_reality": {
-      "windows": "supported",
-      "mac": "headset_unsupported",
-      "linux": "headset_unsupported",
-      "android": "headset_unsupported",
-      "ios": "headset_unsupported"
-    }
-  }
+  "platforms": [
+    "windows"
+  ]
 }


### PR DESCRIPTION
I noticed that information was spread out in a bunch of different files, so I made some changes to consolidate it somewhat.

- The `platforms` entry in the data files has been changed. In the browser data, it is a JSON object mapping the operating systems the browser supports to the headsets it supports on those platforms. In the headset data, it is an array of supported operating systems.
- The list of browsers, headsets, and operating systems to display is automatically computed.
- The compatibility tables now show a more visible indication of whether a browser is unsupported because the headset doesn't support the OS or because the browser doesn't support the headset. Example:
![Screen Shot 2019-04-23 at 9 31 44 PM](https://user-images.githubusercontent.com/12983479/56628385-33bbd080-660f-11e9-9a20-48940c7079c7.png)